### PR TITLE
dhcp-client: Only request address/router config

### DIFF
--- a/dhcp-client/dhclient.conf
+++ b/dhcp-client/dhclient.conf
@@ -13,11 +13,7 @@
 option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
 
 send host-name = gethostname();
-request subnet-mask, broadcast-address, time-offset, routers,
-	domain-name, domain-name-servers, domain-search, host-name,
-	dhcp6.name-servers, dhcp6.domain-search, dhcp6.fqdn, dhcp6.sntp-servers,
-	netbios-name-servers, netbios-scope, interface-mtu,
-	rfc3442-classless-static-routes, ntp-servers;
+request subnet-mask, broadcast-address, time-offset, routers, interface-mtu;
 
 #send dhcp-client-identifier 1:0:a0:24:ab:fb:9c;
 #send dhcp-lease-time 3600;


### PR DESCRIPTION
Don't request and DNS, NTP, Netbios, etc. configuration attributes from the DHCP server as we're only using DHCP for configurating IP connectivity and Internet access through the external VRF and all our systems should use our internal DNS servers.

Closes #12 